### PR TITLE
Fixed bug where user could not login after logging out

### DIFF
--- a/mdvt/database/util.py
+++ b/mdvt/database/util.py
@@ -15,7 +15,7 @@ def db_insert_if_not_exist(entry, **kwargs):
 def db_get_existing_entry(model, **kwargs):
     existing_entry = model.query
     for key, value in kwargs.items():
-        existing_entry = existing_entry.filter(key == value)
+        existing_entry = existing_entry.filter(getattr(model, key) == value)
     existing_entry = existing_entry.first()
     return existing_entry
 


### PR DESCRIPTION
Caused by a bug in db_get_existing_entry's filter functions,
causing db_insert_if_not_exist to think that the existing user
doesn't exist, thus attmpting to create such an entry, trigerring
the unique rule in a column in the user table.